### PR TITLE
[BUGfIX] Docker Issue: LLVM clang-format 21 unavailable. https://gith…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,7 @@ RUN apt-get update && \
   rm -rf /var/lib/apt/lists/*
 ADD https://apt.llvm.org/llvm-snapshot.gpg.key llvm-snapshot.gpg.key
 RUN apt-key add llvm-snapshot.gpg.key && \
-  apt-add-repository "deb https://apt.llvm.org/jammy/ llvm-toolchain-jammy main" && \
+  apt-add-repository -y "deb https://apt.llvm.org/plucky/ llvm-toolchain-plucky-20 main" && \
   apt-get -y update && \
   apt-get -y install --no-install-recommends --no-install-suggests clang-format-19 && \
   update-alternatives --install /usr/bin/clang-format clang-format $(which clang-format-19) 100 && \


### PR DESCRIPTION
…ub.com/llvm/llvm-project/issues/151221

Using 20 branch: https://github.com/llvm/llvm-project/issues/151221#issuecomment-3137269853